### PR TITLE
More flexibility on dependencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ end
 - `profile_name`, String, name_property: true. # The Dmgr profile name.
 - `node_name`, String, default: lazy { "#{profile_name}_node" }. It's easier to keep the default name here.
 - `cell_name`, [String, nil], default: nil
-- `java_sdk`, [String, nil], default: nil # The javasdk version must be already be installed using ibm-installmgr cookbook. If none is specified the embedded default is used
+- `java_sdk`, [String, nil], default: nil # The javasdk version must be already be installed using ibm-installmgr cookbook. If none is specified the embedded default is used. [See more](http://www.ibm.com/support/knowledgecenter/SS7JFU_8.5.5/com.ibm.websphere.express.doc/ae/rxml_managesdk.html)
 - `security_attributes`, [Hash, nil], default: nil # A hash of security attributes to apply to the dmgr
 - `manage_user`, [TrueClass, FalseClass], default: true. Should the resource create the user for you. Set to false if you have created the run_user previously in your recipe, outside of this resource.
 - `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
@@ -130,9 +130,11 @@ end
 - `node_name`, String, default: lazy { "#{profile_name}_node" }
 - `server_name`, String, default: lazy { "#{profile_name}_server" }
 - `cell_name`, [String, nil], default: nil
-- `java_sdk`, [String, nil], default: nil # The javasdk version must be already be installed using ibm-installmgr cookbook. If none is specified the embedded default is used
+- `java_sdk`, [String, nil], default: nil # The javasdk version must be already be installed using ibm-installmgr cookbook. If none is specified the embedded default is used. [See more](http://www.ibm.com/support/knowledgecenter/SS7JFU_8.5.5/com.ibm.websphere.express.doc/ae/rxml_managesdk.html)
 - `profile_type`, String, default: 'custom', Can be either appserver or custom, but easier to just use custom all the time and add jvms with websphere_app_server or websphere_cluster_member.
 - `attributes`, [Hash, nil], default: nil, These are custom attributes for the server when using the appserver type profile, such as monitoringPolicy. They are only set when the node is federated.
+- `manage_user`, [TrueClass, FalseClass], default: true. Should the resource create the user for you. Set to false if you have created the run_user previously in your recipe, outside of this resource.
+- `manage_service`, [TrueClass, FalseClass], default: true. Should the resource create the init service for you. Set to false if you have created the service previously in your recipe, outside of this resource.
 - `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
 
 ##### Actions

--- a/libraries/websphere_base.rb
+++ b/libraries/websphere_base.rb
@@ -53,7 +53,7 @@ module WebsphereCookbook
       # returns a hash of enpoint => port for a server
       # if server is nil it returns an array of all servers endpoints and ports
       # returns nil if error
-      def get_ports(srvr_name = '', bin_directory = '/opt/IBM/WebSphere/AppServer/bin')
+      def get_ports(srvr_name = '', bin_directory = bin_dir)
         cookbook_file "#{bin_directory}/server_ports.py" do
           cookbook 'websphere'
           source 'server_ports.py'

--- a/libraries/websphere_dmgr.rb
+++ b/libraries/websphere_dmgr.rb
@@ -51,7 +51,7 @@ module WebsphereCookbook
         manageprofiles_exec('./manageprofiles.sh -create', options)
       end
 
-      # set java sdk if set
+      # Enable "profile_name" to use the specific "java_sdk"
       if java_sdk
         current_java = current_java_sdk(profile_name)
         enable_java_sdk(java_sdk, "#{profile_path}/bin", profile_name) if p_exists && current_java != java_sdk

--- a/libraries/websphere_profile.rb
+++ b/libraries/websphere_profile.rb
@@ -47,8 +47,10 @@ module WebsphereCookbook
         end
 
         # set java sdk if set
-        current_java = current_java_sdk(profile_name)
-        enable_java_sdk(java_sdk, "#{profile_path}/bin", profile_name) if java_sdk && current_java != java_sdk # only update if java version changes
+        if java_sdk
+          current_java = current_java_sdk(profile_name)
+          enable_java_sdk(java_sdk, "#{profile_path}/bin", profile_name) if current_java != java_sdk
+        end
       end
     end
 

--- a/libraries/websphere_profile.rb
+++ b/libraries/websphere_profile.rb
@@ -28,8 +28,10 @@ module WebsphereCookbook
     property :run_user, String, default: 'was'
     property :attributes, [Hash, nil], default: nil # these are only set if the node is federated.
     property :server_name, [String, nil], default: nil
-    # creates a new profile or augments/updates if profile exists.
+    property :manage_user, [TrueClass, FalseClass], default: true
+    property :manage_service, [TrueClass, FalseClass], default: true
 
+    # creates a new profile or augments/updates if profile exists.
     action :create do
       unless profile_exists?(profile_name)
         template_path = template_lookup(profile_type, profile_templates_dir)
@@ -58,8 +60,10 @@ module WebsphereCookbook
       federated = federated?(profile_path, node_name)
       if profile_exists?(profile_name) && !federated
         add_node("#{profile_path}/bin")
-        create_service_account(run_user) unless run_user == 'root'
-        enable_as_service(node_name, 'nodeagent', profile_path, run_user)
+        unless run_user == 'root' || manage_user == false
+          create_service_account(run_user)
+        end
+        enable_as_service(node_name, 'nodeagent', profile_path, run_user) if manage_service == true
       end
 
       # set attributes on server

--- a/libraries/websphere_profile.rb
+++ b/libraries/websphere_profile.rb
@@ -48,7 +48,7 @@ module WebsphereCookbook
           action :run
         end
 
-        # set java sdk if set
+        # Enable "profile_name" to use the specific "java_sdk"
         if java_sdk
           current_java = current_java_sdk(profile_name)
           enable_java_sdk(java_sdk, "#{profile_path}/bin", profile_name) if current_java != java_sdk


### PR DESCRIPTION
A few fixes to make the cookbook more flexible

* Ignore javasdk if the attribute is not defined. see #10 for more context. The fix was applied to websphere_dmgr.
* Use bindir attr rather than hardcoded value
* Allow to disable user or service creation like for websphere_dmgr