### PR TITLE
Allow group to be specified for manageprofiles commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,5 @@ script:
 after_script:
 - cat .kitchen/logs/kitchen.log
 before_install:
-- openssl aes-256-cbc -K $encrypted_deb391b403a8_key -iv $encrypted_deb391b403a8_iv
+- [ "${TRAVIS_PULL_REQUEST}" = "false" ] && openssl aes-256-cbc -K $encrypted_deb391b403a8_key -iv $encrypted_deb391b403a8_iv
   -in travis-ci.pem.enc -out travis-ci.pem -d

--- a/libraries/websphere_base.rb
+++ b/libraries/websphere_base.rb
@@ -44,6 +44,7 @@ module WebsphereCookbook
         execute "manage_profiles #{cmd} #{profile_name}" do
           cwd bin_dir
           user run_user
+          group run_group
           command command
           sensitive sensitive_exec
           action :run
@@ -168,10 +169,15 @@ module WebsphereCookbook
         end
       end
 
-      def create_service_account(user)
+      def create_service_account(user, group)
+        group group do
+          action :create
+          not_if { user == 'root' }
+        end
         user user do
           comment 'websphere service account'
           home "/home/#{user}"
+          group group
           shell '/sbin/nologin'
           not_if { user == 'root' }
         end
@@ -185,9 +191,9 @@ module WebsphereCookbook
           not_if { user == 'root' }
         end
 
-        # there's no perfect way to chown in chef without being explicit for each dir with the directlry resource.
+        # there's no perfect way to chown in chef without being explicit for each dir with the directory resource.
         execute 'chown websphere root for service account' do
-          command "chown -R #{user}:root #{websphere_root}"
+          command "chown -R #{user}:#{group} #{websphere_root}"
           action :run
         end
       end

--- a/libraries/websphere_dmgr.rb
+++ b/libraries/websphere_dmgr.rb
@@ -30,12 +30,13 @@ module WebsphereCookbook
     property :java_sdk, [String, nil], default: nil # javasdk version must be already be installed using ibm-installmgr cookbook. If none is specified the embedded default is used
     property :security_attributes, [Hash, nil], default: nil # these are set when the Dmgr is started
     property :run_user, String, default: 'was'
+    property :run_group, String, default: 'was'
     property :manage_user, [TrueClass, FalseClass], default: true
 
     # creates a new profile or augments/updates if profile exists.
     action :create do
       unless run_user == 'root' || manage_user == false
-        create_service_account(run_user)
+        create_service_account(run_user, run_group)
       end
 
       p_exists = profile_exists?(profile_name)

--- a/libraries/websphere_profile.rb
+++ b/libraries/websphere_profile.rb
@@ -26,6 +26,7 @@ module WebsphereCookbook
     resource_name :websphere_profile
     property :profile_type, String, default: 'custom', regex: /^(appserver|custom)$/
     property :run_user, String, default: 'was'
+    property :run_group, String, default: 'was'
     property :attributes, [Hash, nil], default: nil # these are only set if the node is federated.
     property :server_name, [String, nil], default: nil
     property :manage_user, [TrueClass, FalseClass], default: true
@@ -44,6 +45,8 @@ module WebsphereCookbook
         execute "manage_profiles -create #{profile_name}" do
           cwd bin_dir
           command cmd
+          user run_user
+          group run_group
           sensitive true
           action :run
         end
@@ -61,7 +64,7 @@ module WebsphereCookbook
       if profile_exists?(profile_name) && !federated
         add_node("#{profile_path}/bin")
         unless run_user == 'root' || manage_user == false
-          create_service_account(run_user)
+          create_service_account(run_user, run_group)
         end
         enable_as_service(node_name, 'nodeagent', profile_path, run_user) if manage_service == true
       end

--- a/test/integration/was-cluster/serverspec/default_spec.rb
+++ b/test/integration/was-cluster/serverspec/default_spec.rb
@@ -41,6 +41,8 @@ services.each do |service|
 end
 
 describe file('/opt/IBM/WebSphere/AppServer/profiles/Dmgr01/config/cells/MyNewCell/nodes/CustomProfile1_node/servers/ClusterServer1/server.xml') do
+  it { should be_owned_by 'was' }
+  it { should be_grouped_into 'was' }
   its(:content) { should match(/<jvmEntries.*initialHeapSize="1024".*maximumHeapSize="3072".*debugMode="true"/) }
   its(:content) { should match(/maximumStartupAttempts="2"/) }
   its(:content) { should match(/pingInterval="222"/) }


### PR DESCRIPTION
- Add group to user creation on the service account
- Add group to the execute resources of manageprofile.sh commands