### PR TITLE
add user parameter to many commands to ensure context is maintained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 IBM Websphere Cookbook CHANGELOG
 ========================
 
+v1.0.4
+--------------------
+- add user parameter to commands so files are not owned by root in contexts where we are running as user
+
+v1.0.3
+--------------------
+- ensure server members with the same name on different nodes do not clash on cluster member checks
+- add group setting to certain commands
 v1.0.2
 --------------------
 - use cookstyle for style check

--- a/libraries/websphere_base.rb
+++ b/libraries/websphere_base.rb
@@ -24,6 +24,8 @@ module WebsphereCookbook
     resource_name :websphere_base
     property :websphere_root, String, default: '/opt/IBM/WebSphere/AppServer'
     property :bin_dir, String, default: lazy { "#{websphere_root}/bin" }
+    property :run_user, String, default: 'was'
+    property :run_group, String, default: 'was'
     property :admin_user, [String, nil], default: nil
     property :admin_password, [String, nil], default: nil
     property :dmgr_host, String, default: 'localhost' # dmgr host to federate to.

--- a/libraries/websphere_base.rb
+++ b/libraries/websphere_base.rb
@@ -78,6 +78,7 @@ module WebsphereCookbook
 
         execute "stop #{p_name}" do
           cwd profile_bin
+          user run_user
           command cmd
           returns [0, 246, 255]
           sensitive sensitive_exec
@@ -92,6 +93,7 @@ module WebsphereCookbook
         # start_profile(profile_name, "#{profile_path}/bin", "./startNode.sh", [0, 255])
         execute "start node on profile: #{profile_bin}" do
           cwd profile_bin
+          user run_user
           command './startNode.sh'
           returns [0, 255] # ignore error if node already started.
           action :run
@@ -110,6 +112,7 @@ module WebsphereCookbook
 
         execute "sync node on profile: #{profile_bin}" do
           cwd profile_bin
+          user run_user
           command cmd
           returns [0]
           action :run
@@ -136,6 +139,7 @@ module WebsphereCookbook
         # start_profile(profile_name, bin_dir, "./startManager.sh -profileName #{profile_name}", [0, 255])
         execute "start dmgr profile: #{p_name}" do
           cwd bin_dir
+          user run_user
           command "./startManager.sh -profileName #{p_name}"
           returns [0, 255] # ignore error if node already started.
           action :run
@@ -208,6 +212,7 @@ module WebsphereCookbook
 
         execute "addNode #{profile_bin_dir}" do
           cwd profile_bin_dir
+          user run_user
           command cmd
           sensitive sensitive_exec
           action :run
@@ -225,6 +230,7 @@ module WebsphereCookbook
 
         execute "removeNode #{profile_bin_dir}" do
           cwd bin_dir
+          user run_user
           command cmd
           sensitive sensitive_exec
           action :run
@@ -238,6 +244,7 @@ module WebsphereCookbook
         cmd << " -username #{admin_user} -password #{admin_password}" if admin_user && admin_password
         execute "cleanupNode node: #{nde_name} dmgr: #{dmgr_host}" do
           cwd bin_dir
+          user run_user
           command cmd
           sensitive sensitive_exec
           action :run
@@ -247,6 +254,7 @@ module WebsphereCookbook
       def update_registry
         execute 'update profile registry' do
           cwd bin_dir
+          user run_user
           command './manageprofiles.sh -validateAndUpdateRegistry'
           action :run
         end
@@ -272,6 +280,7 @@ module WebsphereCookbook
       def delete_profile(p_name, p_path)
         execute "delete #{p_name}" do
           cwd bin_dir
+          user run_user
           command "./manageprofiles.sh -delete -profileName #{p_name} && "\
             './manageprofiles.sh -validateAndUpdateRegistry'
           returns [0, 2]
@@ -292,6 +301,7 @@ module WebsphereCookbook
         cmd << " -user #{admin_user} -password #{admin_password}" if admin_user && admin_password
         execute "enable java #{sdk_name} on profile: #{profile_name}" do
           cwd profile_bin
+          user run_user
           command cmd
           action :run
         end
@@ -467,6 +477,7 @@ module WebsphereCookbook
 
         execute "wsadmin #{label}" do
           cwd bin_directory
+          user run_user
           command wsadmin_cmd
           returns return_codes
           sensitive sensitive_exec
@@ -484,6 +495,7 @@ module WebsphereCookbook
 
         execute "wsadmin #{label}" do
           cwd bin_directory
+          user run_user
           command wsadmin_cmd
           returns return_codes
           sensitive sensitive_exec

--- a/libraries/websphere_dmgr.rb
+++ b/libraries/websphere_dmgr.rb
@@ -29,8 +29,6 @@ module WebsphereCookbook
     property :profile_templates_dir, String, default: lazy { "#{websphere_root}/profileTemplates" }
     property :java_sdk, [String, nil], default: nil # javasdk version must be already be installed using ibm-installmgr cookbook. If none is specified the embedded default is used
     property :security_attributes, [Hash, nil], default: nil # these are set when the Dmgr is started
-    property :run_user, String, default: 'was'
-    property :run_group, String, default: 'was'
     property :manage_user, [TrueClass, FalseClass], default: true
 
     # creates a new profile or augments/updates if profile exists.

--- a/libraries/websphere_profile.rb
+++ b/libraries/websphere_profile.rb
@@ -25,8 +25,6 @@ module WebsphereCookbook
 
     resource_name :websphere_profile
     property :profile_type, String, default: 'custom', regex: /^(appserver|custom)$/
-    property :run_user, String, default: 'was'
-    property :run_group, String, default: 'was'
     property :attributes, [Hash, nil], default: nil # these are only set if the node is federated.
     property :server_name, [String, nil], default: nil
     property :manage_user, [TrueClass, FalseClass], default: true

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'lachlan.munro@sainsburys.co.uk'
 license 'Apache 2.0'
 description 'Installs/Configures IBM Websphere'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.3'
+version '1.0.4'
 supports 'redhat'
 supports 'centos'
 


### PR DESCRIPTION
- many commands are running as root in contexts where we are running as a non-root user. This causes issues with starting/stopping nodes and manageprofile commands where files are owned by root and causing failures.