### PR TITLE
Add update action to ibm_cert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 IBM Websphere Cookbook CHANGELOG
 ========================
+v1.0.5
+--------------------
+- add update action for IBM certificate import
 
 v1.0.4
 --------------------
@@ -9,6 +12,7 @@ v1.0.3
 --------------------
 - ensure server members with the same name on different nodes do not clash on cluster member checks
 - add group setting to certain commands
+
 v1.0.2
 --------------------
 - use cookstyle for style check

--- a/README.md
+++ b/README.md
@@ -414,6 +414,8 @@ end
 - `:create` - Creates a keystore with a default certificate
 - `:extract` - extracts a certificate from a keystore
 - `:add` - adds an existing certificate to an existing keystore.
+- `:import` - import a new certificate to an existing keystore.
+- `:update` - update a certificate in an existing keystore with the same label.
 
 
 ### websphere_env

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'lachlan.munro@sainsburys.co.uk'
 license 'Apache 2.0'
 description 'Installs/Configures IBM Websphere'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.4'
+version '1.0.5'
 supports 'redhat'
 supports 'centos'
 


### PR DESCRIPTION
- Add update action to ibm_cert. This allows the update of a particular label within the keystore via delete & reimport. It checks the SHA256 fingerprint of the certificate to be imported against the keystore label and will do nothing if they match.