### PR TITLE
Update to allow setting of attributes against a JMS provider

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -55,5 +55,45 @@ module WebsphereCookbook
       }
       mgmttype[profle_type]
     end
+
+# Generic convert to wsadmin array
+# We convert a ruby hash / array into a [] bracket string which is understood by wsadmin script.
+# Each kvp in a hash is surrounded by [] and then if the value is an object it is in-turn passed
+# through the method to ensure the correct wrapping.
+# Sample ruby input { 'foo' => [ { 'bar' => 'car', 'a' => 'b'}, {'c' => 'd', 'e' =>'f'} ] }
+#             output [['foo' [[['bar','car'],['a','b']],[['c','d'],['e','f']]]]]
+    def attributes_to_wsadmin_str(an_object)
+      attribute_str = ''
+      if !an_object.nil?
+# Need to determine how to preceed based on the object type
+        if an_object.is_a?(Hash)
+          last_index = an_object.size - 1
+          attribute_str.concat('[')
+          an_object.each_with_index do |(k, v), index|
+            attribute_str.concat('[')
+            attribute_str.concat("'#{k}', #{attributes_to_wsadmin_str(v)}")
+            attribute_str.concat(']')
+            if index < last_index
+              attribute_str.concat(', ')
+            end
+          end
+          attribute_str.concat(']')
+        elsif an_object.is_a?(Array)
+          last_index = an_object.size - 1
+          attribute_str.concat('[')
+          an_object.each_with_index do |v, index|
+            attribute_str.concat(attributes_to_wsadmin_str(v))
+            if index < last_index
+              attribute_str.concat(', ')
+            end
+          end
+          attribute_str.concat(']')
+        else
+# I'm just a simple value
+          attribute_str.concat("'#{an_object}'")
+        end
+      end
+      attribute_str
+    end
   end
 end

--- a/libraries/websphere_jms_provider.rb
+++ b/libraries/websphere_jms_provider.rb
@@ -30,16 +30,18 @@ module WebsphereCookbook
     property :url, [String, nil], default: nil
     property :classpath_jars, [Array, nil], default: nil # full path to each jar
     property :description, [String, nil], default: nil
-
+    property :attributes, [Hash, nil], default: { } # Generic hash holding attributes for the provider - see : https://www.ibm.com/support/knowledgecenter/en/SS7K4U_7.0.0/com.ibm.websphere.zseries.doc/info/zseries/ae/rxml_7adminjms.html (ignore that it's for zOS) 
     action :create do
       unless jms_provider_exists?
+        @jmsattrs = attributes.merge( {'classpath' => "#{classpath_jars.join(';')}" } )
+        @jmsattrs.merge!( {'description' => "#{description}" } )
+        @attributes_str = attributes_to_wsadmin_str(@jmsattrs)
         cmd = "AdminJMS.createJMSProviderAtScope('#{scope}', '#{provider_name}', "\
-          "'#{context_factory}', '#{url}', [['classpath', '#{classpath_jars.join(';')}'], ['description', '#{description}']])"
+          "'#{context_factory}', '#{url}', #{@attributes_str})"
 
         wsadmin_exec("Create JMS Provider #{provider_name}", cmd)
       end
     end
-
     # need to wrap helper methods in class_eval
     # so they're available in the action.
     action_class.class_eval do


### PR DESCRIPTION
Update to the JMS provider to allow us to pass in a hash of additional properties which need to be set against the provider. To allow backward compatibility I've left the existing method signature in place which allows the passing in of class path entries and the description (even though these technically belong in the properties hash). 

I had to add a recursive function to allow us to build a wsadmin acceptable script from the hash; tested out against our own chef code for building GOL and it works fine.