### PR TITLE
Don't add a new cluster template if one exists

### DIFF
--- a/libraries/websphere_base.rb
+++ b/libraries/websphere_base.rb
@@ -630,6 +630,26 @@ module WebsphereCookbook
         wsadmin_exec("wsadmin deploy #{appl_file} to cluster #{clus_name}", cmd)
         save_config
       end
+
+      # Retrieve those cluster templates already defined for a cluster
+      def get_cluster_templates(clus_name)
+        cmd = "-c \"AdminTask.listClusterMemberTemplates('[-clusterName #{clus_name}]')\""
+        mycmd = wsadmin_returns(cmd)
+        # example output:'V7MemberTemplate(templates/clusters/sample-cluster/servers/V7MemberTemplate|server.xml#Server_1506097558200)\nV7MemberTemplate0(templates/clusters/sample-cluster/servers/V7MemberTemplate0|server.xml#Server_1508144541044)'
+        was_templates = []
+        return was_templates if mycmd.error?
+        str = mycmd.stdout.chomp.match(/'(.*?)'/) # get only what's between ''.
+        return was_templates if str.nil?
+        str_match = str.captures.first
+        # get the first match only, removing outer brackets ['']
+        raw_servers = str_match.split("\n")
+        raw_servers.each do |s|
+          was_template = s.split('(')[0]
+          was_templates << was_template
+        end
+        Chef::Log.debug("get_cluster_templates() result #{was_templates}")
+        was_templates
+      end
     end
   end
 end


### PR DESCRIPTION
Update the WebSphere_cluster_member and base recipes so that we don't create a new template when adding what appears to be the first node to a cluster IF a cluster template already exists. If we don't do this then we create a default template without any settings that might be required.

We spotted this in the WCS repo; there we create a temporary cluster member during cluster creation to create a template with all of the properties we need for newly added servers to have; however the next cluster member addition through the WebSphere_cluster_member cookbook would create a new (duff) template which wouldn't allow the application to function.