### PR TITLE
add ability to specify a template for new cluster member

### DIFF
--- a/libraries/websphere_cluster_member.rb
+++ b/libraries/websphere_cluster_member.rb
@@ -14,21 +14,33 @@ module WebsphereCookbook
     property :resources_scope, String, default: 'both', regex: /^(both|server|cluster)$/
     property :generate_unique_ports, [TrueClass, FalseClass], default: true
     property :attributes, [Hash, nil], default: nil
+    property :template_node_name, [String, nil], default: nil, required: false
+    property :template_server_name, [String, nil], default: nil, required: false
 
     # creates a new profile or augments/updates if profile exists.
     action :create do
       # make sure cluster exists, and we're not adding a server that already exists in a cluster.
       if cluster_exists?(cluster_name) && !member_of_cluster?(server_name, server_node)
-        if get_cluster_members(cluster_name).count > 0 || get_cluster_templates(cluster_name).count > 0
+        if get_cluster_members(cluster_name).count > 0
           # this will NOT be the first member (or we have defined a template at some point). Add as additional
+          # There is a horrible WAS 'feature' that means that even if a template has been defined on a cluster, if there are no members
+          # in it, then when you add a new JVM WAS takes this as a new template with the default applciation profile.
           Chef::Log.info('Not creating first member, either existing members or templates exist')
           cmd = "AdminTask.createClusterMember(['-clusterName', '#{cluster_name}', '-memberConfig', '[-memberNode #{server_node} "\
             "-memberName #{server_name} -memberWeight #{member_weight} -genUniquePorts #{generate_unique_ports} -replicatorEntry #{session_replication}]'])"
           wsadmin_exec("wsadmin add additional member: #{server_name} to cluster: #{cluster_name} ", cmd)
         else
-          # this will be the first member and be the template for further cluster members
+          # this will be the first member and be the template for further cluster members. Decide if we have a template server elsewhere to use
           Chef::Log.info('Creating first cluster member and template')
-          cmd = "AdminClusterManagement.createFirstClusterMemberWithTemplate('#{cluster_name}', '#{server_node}', '#{server_name}', 'default')"
+          cmd = nil
+          if template_node_name != nil && template_server_name != nil
+            Chef::Log.info("Using node #{template_node_name} and server #{template_server_name} as a template")
+            cmd = "AdminClusterManagement.createFirstClusterMemberWithTemplateNodeServer('#{cluster_name}', '#{server_node}', '#{server_name}', '#{template_node_name}', '#{template_server_name}')"
+          else
+            # This will create a standard WAS server using the default application server template
+            Chef::Log.info('Creating new member using default application server template')
+            cmd = "AdminClusterManagement.createFirstClusterMemberWithTemplate('#{cluster_name}', '#{server_node}', '#{server_name}', 'default')"
+          end 
           wsadmin_exec("wsadmin add first cluster member: #{server_name} to cluster: #{cluster_name} ", cmd)
         end
       end


### PR DESCRIPTION
Well the first attempt at fixing the templating issue for clusters didn't work as expected. Turns out that WAS ignores any defined template on a cluster if there are no cluster members. When you add the first member it then uses the default application server template (which is very simple) and creates a cluster template from this which is then used for all other server additions.

I've updated the cluster_member recipe to allow us to pass in a template node and server to use to create the template if there are no other servers in the cluster.