### PR TITLE
Use pure wsadmin to determine cluster membership

### DIFF
--- a/files/default/cluster_member_exists.py
+++ b/files/default/cluster_member_exists.py
@@ -1,0 +1,32 @@
+import sys
+
+def listServersInCluster(clusterName):
+    clusterId = AdminConfig.getid("/ServerCluster:" + clusterName + "/")
+    clusterMembers = _splitlines(AdminConfig.list("ClusterMember", clusterId ))
+    return clusterMembers
+
+def _splitlines(s):
+  rv = [s]
+  if '\r' in s:
+    rv = s.split('\r\n')
+  elif '\n' in s:
+    rv = s.split('\n')
+  if rv[-1] == '':
+    rv = rv[:-1]
+  return rv
+
+clusterName = sys.argv[0]
+print clusterName
+nodeName = sys.argv[1]
+print nodeName
+serverName = sys.argv[2]
+print serverName
+clusterMembers = listServersInCluster(clusterName)
+is_found = 0 
+for clusterMember in clusterMembers:
+  clusterNodeName = AdminConfig.showAttribute( clusterMember, "nodeName" )
+  if clusterNodeName == nodeName:
+    clusterServerName = AdminConfig.showAttribute( clusterMember, "memberName" )
+    if clusterServerName == serverName:
+      is_found = 1
+print "===%s===" % (is_found)

--- a/libraries/websphere_cluster_member.rb
+++ b/libraries/websphere_cluster_member.rb
@@ -20,7 +20,7 @@ module WebsphereCookbook
     # creates a new profile or augments/updates if profile exists.
     action :create do
       # make sure cluster exists, and we're not adding a server that already exists in a cluster.
-      if cluster_exists?(cluster_name) && !member_of_cluster?(server_name, server_node)
+      if cluster_exists?(cluster_name) && !member?(cluster_name, server_name, server_node)
         if get_cluster_members(cluster_name).count > 0
           # this will NOT be the first member (or we have defined a template at some point). Add as additional
           # There is a horrible WAS 'feature' that means that even if a template has been defined on a cluster, if there are no members


### PR DESCRIPTION
Previously our add server to node mechanism was a bit on the slow side as we had to keep bouncing back between ruby and wsadmin code to look at each server on each node in all the clusters in the cell. The performance was therefore a multiplier of the number of nodes and servers currently configured along with the wsadmin connect time (which can be many many seconds).

I've now written a simple bit of wsasdmin script which performs all the look ups in a single invocation passing back the result to the ruby code.

Things to note: I've had to add real recipes to the repo to allow us to create the relevant wsadmin lookup. Really I think we need to migrate all of the wsadmin back into these recipes to ensure they are created. Library functions don't run in the same context as a recipe code and according to the docs I've been reading one shouldn't really be using DSL within them (well not without a bunch of hoop jumping). 

This does mean that we have to configure the websphere recipe in the wrapping recipe setting the node['websphere']['location'] property to specify where we want the files placed on the server.