### PR TITLE
Change name_property for the websphere_dmgr and websphere_profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,14 @@ end
 
 ##### Parameters
 
+- `label`, String, name_property: true, just a label to make the execute resource name unique
 - `websphere_root`, String, default: '/opt/IBM/WebSphere/AppServer', The was install root
 - `bin_dir`, String, default: lazy { "#{websphere_root}/bin" } The path to the was root bin directory. No need to change this.
 - `admin_user`, [String, nil], default: nil, The dmgr user.  
 - `admin_password`, [String, nil], default: nil, The dmgr password.  This should only be known to people who know the server is managed with chef.
 - `dmgr_host`, String, default: 'localhost', The dmgr host/ip.
 - `dmgr_port`, [String, nil], default: nil, The dmgr port, when nil WAS will default to dmgr SOAP connector default port 8879.
-- `profile_name`, String, name_property: true. # The Dmgr profile name.
+- `profile_name`, String, # The Dmgr profile name.
 - `node_name`, String, default: lazy { "#{profile_name}_node" }. It's easier to keep the default name here.
 - `cell_name`, [String, nil], default: nil
 - `java_sdk`, [String, nil], default: nil # The javasdk version must be already be installed using ibm-installmgr cookbook. If none is specified the embedded default is used. [See more](http://www.ibm.com/support/knowledgecenter/SS7JFU_8.5.5/com.ibm.websphere.express.doc/ae/rxml_managesdk.html)
@@ -121,13 +122,14 @@ end
 
 ##### Parameters
 
+- `label`, String, name_property: true, just a label to make the execute resource name unique
 - `websphere_root`, String, default: '/opt/IBM/WebSphere/AppServer', The was install root
 - `bin_dir`, String, default: lazy { "#{websphere_root}/bin" } The path to the was root bin directory. No need to change this.
 - `admin_user`, [String, nil], default: nil, The dmgr user.  
 - `admin_password`, [String, nil], default: nil, The dmgr password.  This should only be known to people who know the server is managed with chef.
 - `dmgr_host`, String, default: 'localhost', The dmgr host to federate to.
 - `dmgr_port`, [String, nil], default: nil, The dmgr port to federate to.
-- `profile_name`, String, name_property: true
+- `profile_name`, String
 - `node_name`, String, default: lazy { "#{profile_name}_node" }
 - `server_name`, String, default: lazy { "#{profile_name}_server" }
 - `cell_name`, [String, nil], default: nil
@@ -587,7 +589,7 @@ end
 
 ##### Parameters
 
-- `label`, String, name_property: true just a label to make the execute resource name unique
+- `label`, String, name_property: true, just a label to make the execute resource name unique
 - `script`, [String, nil], default: nil. The command for wsadmin to run.  If a file is given this will be ignored, and only the file will be executed.
 - `file`, [String, nil], default: nil The script file for wsadmin to run.
 - `return_codes`, Array, default: [0]. Return codes to allow.

--- a/libraries/websphere_dmgr.rb
+++ b/libraries/websphere_dmgr.rb
@@ -22,7 +22,8 @@ module WebsphereCookbook
 
     resource_name :websphere_dmgr
 
-    property :profile_name, String, name_property: true
+    property :label, String, name_property: true
+    property :profile_name, String, required: true
     property :profile_path, String, default: lazy { "#{websphere_root}/profiles/#{profile_name}" }
     property :node_name, String, default: lazy { "#{profile_name}_node" }
     property :cell_name, [String, nil], default: nil

--- a/test/fixtures/cookbooks/websphere-test/recipes/was_app_server.rb
+++ b/test/fixtures/cookbooks/websphere-test/recipes/was_app_server.rb
@@ -1,6 +1,7 @@
 include_recipe 'websphere-test::was_install_basic'
 
-websphere_dmgr 'Dmgr01' do
+websphere_dmgr 'Dmgr01 create' do
+  profile_name 'Dmgr01'
   cell_name 'MyNewCell'
   admin_user 'admin'
   admin_password 'admin'
@@ -8,7 +9,8 @@ websphere_dmgr 'Dmgr01' do
   action [:create, :start]
 end
 
-websphere_profile 'Custom' do
+websphere_profile 'Custom profile create and federate' do
+  profile_name 'Custom'
   profile_type 'custom'
   admin_user 'admin'
   admin_password 'admin'
@@ -67,7 +69,8 @@ log 'test restarting app' do
   notifies :start, 'websphere_app[sample_app]', :immediately
 end
 
-websphere_profile 'App_Profile' do
+websphere_profile 'App_Profile create/federate/start' do
+  profile_name 'App_Profile'
   profile_type 'appserver'
   server_name 'AppProfile_server'
   admin_user 'admin'

--- a/test/fixtures/cookbooks/websphere-test/recipes/was_cluster.rb
+++ b/test/fixtures/cookbooks/websphere-test/recipes/was_cluster.rb
@@ -1,7 +1,8 @@
 include_recipe 'websphere-test::was_install_basic'
 include_recipe 'websphere-test::was_fixpack_java7'
 
-websphere_dmgr 'Dmgr01' do
+websphere_dmgr 'Dmgr01 create' do
+  profile_name 'Dmgr01'
   cell_name 'MyNewCell'
   admin_user 'admin'
   admin_password 'admin'
@@ -15,7 +16,8 @@ end
 ## Create, federate, start and set custom attributes
 ## Create, start, federate
 ## delete, create, federate, and set custom attributes start with same name
-websphere_profile 'AppProfile1' do
+websphere_profile 'AppProfile1 create/federate/start' do
+  profile_name 'AppProfile1'
   admin_user 'admin'
   admin_password 'admin'
   attributes ({
@@ -35,7 +37,8 @@ end
 ## create two Custom Nodes to use in cluster
 ## create, federate both nodes.
 ## delete, create, federate one of the nodes custom nodes with same name
-websphere_profile 'CustomProfile1' do
+websphere_profile 'CustomProfile1 create/federate' do
+  profile_name 'CustomProfile1'
   profile_type 'custom'
   admin_user 'admin'
   admin_password 'admin'

--- a/test/fixtures/cookbooks/websphere-test/recipes/was_jms_env_vhost.rb
+++ b/test/fixtures/cookbooks/websphere-test/recipes/was_jms_env_vhost.rb
@@ -1,7 +1,8 @@
 
 include_recipe 'websphere-test::was_install_basic'
 
-websphere_dmgr 'Dmgr01' do
+websphere_dmgr 'Dmgr01 create' do
+  profile_name 'Dmgr01'
   cell_name 'MyNewCell'
   admin_user 'admin'
   admin_password 'admin'

--- a/test/fixtures/cookbooks/websphere-test/recipes/was_webserver.rb
+++ b/test/fixtures/cookbooks/websphere-test/recipes/was_webserver.rb
@@ -2,7 +2,8 @@
 include_recipe 'websphere-test::was_install_basic'
 include_recipe 'websphere-test::ihs_install'
 
-websphere_dmgr 'Dmgr01' do
+websphere_dmgr 'Dmgr01 create' do
+  profile_name 'Dmgr01'
   cell_name 'MyNewCell'
   admin_user 'admin'
   admin_password 'admin'
@@ -10,7 +11,8 @@ websphere_dmgr 'Dmgr01' do
 end
 
 # create additional Custom Node to use in cluster
-websphere_profile 'Custom01' do
+websphere_profile 'Custom01 create/federate' do
+  profile_name 'Custom01'
   profile_type 'custom'
   admin_user 'admin'
   admin_password 'admin'


### PR DESCRIPTION
This change is to make them unique and to avoid resource duplication for Chef 13+ usage.