### PR TITLE
DMgr init script update to use startManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 IBM Websphere Cookbook CHANGELOG
 ========================
 
+v1.0.12
+--------------------
+- Change Deployment Manager init script to use startManager.sh and stopManager.sh
+- Allow use of environment variables with the dmgr profile
+
 v1.0.11
 --------------------
 - update README docs with WAS ND 7.0

--- a/README.md
+++ b/README.md
@@ -1,51 +1,57 @@
-# Websphere Cookbook
+# WebSphere Cookbook
 
 [![Build Status](https://travis-ci.org/Sainsburys/chef-websphere.svg?branch=master)](https://travis-ci.org/Sainsburys/chef-websphere)
 
 ## Scope
 
-This cookbook installs and configures Websphere Application Server Network Deployment (WAS-ND). It has only been tested with a Deployment Manager and Managed nodes.
+This cookbook installs and configures WebSphere Application Server Network Deployment (WAS-ND). It has only been tested with a Deployment Manager and Managed nodes.
 
-So far it has only been tested with Websphere ND 7.0 and 8.5.
+So far it has only been tested with WebSphere ND 7.0 and 8.5.
 
 The cookbook lacks idempotency as querying WAS for the current state is overly complex, really slow, or just not possible.  For that reason it's better to destroy and recreate objects rather than update them at this stage.
 
 ## Requirements
+
 * Chef 12.5 or higher
 * Installation media for Installation manager either local or via a url, and Media or repositories for any other packages like WAS ND, IHS etc.
-* You will first need to install Websphere Network Deployment version using the ibm-installmgr cookbook.  See test/fixtures/cookbooks/webshpere-test/recipes/was_install.rb for an example.
+* You will first need to install WebSphere Network Deployment version using the ibm-installmgr cookbook.  See `test/fixtures/cookbooks/websphere-test/recipes/was_install.rb` for an example.
 
 ## Platform
-* Centos 6
+
+* CentOS 6
 * Red Hat Enterprise 6
 
 ## Versions
+
 • WASND 7.0
 • WASND 8.5
 
 ## Usage
 
 The general pattern for usage is to:
+
 1. Instal Installation Manager with the installation manager cookbook
-2. Install Websphere ND, Websphere Toolbox and Websphere Plugins (for IHS)
-2. Deploy a Dmgr
-3. Deploy a custom profile
-4. Deploy an appserver OR Deploy a cluster and add a cluster member to the profile
-5. Deploy IHS if needed.
+2. Install WebSphere ND, WebSphere Toolbox and WebSphere Plugins (for IHS)
+3. Deploy a Deployment Manager
+4. Deploy a custom profile
+5. Deploy an appserver OR Deploy a cluster and add a cluster member to the profile
+6. Deploy IHS if needed.
 
 ### Install
 
 You first need to install the necessary components. To do this use the ibm-installmgr cookbook.  It can be used to install any of the following:
-  - Websphere ND
-  - Any Websphere ND Fixpacks
-  - IBM Java version(s)
-  - Websphere Plugins (PLG)
-  - Websphere customization toolbox
-  - IHS HTTP Server.
 
-As well as the below example, see test/fixtures/cookbooks/webshpere-test/recipes/was_install.rb for a more complete example.
+* WebSphere ND
+* Any WebSphere ND Fixpacks
+* IBM Java version(s)
+* WebSphere Plugins (PLG)
+* WebSphere customization toolbox
+* IHS HTTP Server.
 
-##### Example
+As well as the below example, see `test/fixtures/cookbooks/websphere-test/recipes/was_install.rb` for a more complete example.
+
+#### Example
+
   ```ruby
   install_mgr 'ibm-im install' do
     install_package 'https://someurl/agent.installer.linux.gtk.x86_64_1.8.4000.20151125_0201.zip'
@@ -64,14 +70,14 @@ As well as the below example, see test/fixtures/cookbooks/webshpere-test/recipes
   end
   ```
 
-
 ### websphere_base
 
 Do not use this directly it can be ignored. This resource is only used as a parent class to share methods between child resources.
 
 ### websphere_dmgr
 
-##### Example
+#### Example
+
 ```ruby
 websphere_dmgr 'Dmgr01' do
   cell_name 'MyNewCell'
@@ -81,36 +87,37 @@ websphere_dmgr 'Dmgr01' do
 end
 ```
 
-##### Parameters
+#### Parameters
 
-- `label`, String, name_property: true, just a label to make the execute resource name unique
-- `websphere_root`, String, default: '/opt/IBM/WebSphere/AppServer', The was install root
-- `bin_dir`, String, default: lazy { "#{websphere_root}/bin" } The path to the was root bin directory. No need to change this.
-- `admin_user`, [String, nil], default: nil, The dmgr user.  
-- `admin_password`, [String, nil], default: nil, The dmgr password.  This should only be known to people who know the server is managed with chef.
-- `dmgr_host`, String, default: 'localhost', The dmgr host/ip.
-- `dmgr_port`, [String, nil], default: nil, The dmgr port, when nil WAS will default to dmgr SOAP connector default port 8879.
-- `profile_name`, String, # The Dmgr profile name.
-- `node_name`, String, default: lazy { "#{profile_name}_node" }. It's easier to keep the default name here.
-- `cell_name`, [String, nil], default: nil
-- `java_sdk`, [String, nil], default: nil # The javasdk version must be already be installed using ibm-installmgr cookbook. If none is specified the embedded default is used. [See more](http://www.ibm.com/support/knowledgecenter/SS7JFU_8.5.5/com.ibm.websphere.express.doc/ae/rxml_managesdk.html)
-- `security_attributes`, [Hash, nil], default: nil # A hash of security attributes to apply to the dmgr
-- `manage_user`, [TrueClass, FalseClass], default: true. Should the resource create the user for you. Set to false if you have created the run_user previously in your recipe, outside of this resource.
-- `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
+* `label`, String, name_property: true, just a label to make the execute resource name unique
+* `websphere_root`, String, default: '/opt/IBM/WebSphere/AppServer', The was install root
+* `bin_dir`, String, default: lazy { "#{websphere_root}/bin" } The path to the was root bin directory. No need to change this.
+* `admin_user`, [String, nil], default: nil, The dmgr user.
+* `admin_password`, [String, nil], default: nil, The dmgr password.  This should only be known to people who know the server is managed with chef.
+* `dmgr_host`, String, default: 'localhost', The dmgr host/ip.
+* `dmgr_port`, [String, nil], default: nil, The dmgr port, when nil WAS will default to dmgr SOAP connector default port 8879.
+* `profile_name`, String, name_property: true. # The Dmgr profile name.
+* `profile_env`, [Hash, nil], default: nil, additional environment variables to send to the start command
+* `node_name`, String, default: lazy { "#{profile_name}_node" }. It's easier to keep the default name here.
+* `cell_name`, [String, nil], default: nil
+* `java_sdk`, [String, nil], default: nil # The javasdk version must be already be installed using ibm-installmgr cookbook. If none is specified the embedded default is used. [See more](http://www.ibm.com/support/knowledgecenter/SS7JFU_8.5.5/com.ibm.websphere.express.doc/ae/rxml_managesdk.html)
+* `security_attributes`, [Hash, nil], default: nil # A hash of security attributes to apply to the dmgr
+* `manage_user`, [TrueClass, FalseClass], default: true. Should the resource create the user for you. Set to false if you have created the run_user previously in your recipe, outside of this resource.
+* `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in Chef logs.
 
-##### Actions
+#### Actions
 
-- `:create` - Creates the dmgr
-- `:start` - Starts the dmgr.
-- `:stop` - Stops the dmgr.
-- `:sync_all` - Syncs all federated nodes in the dmgr without restarting the appservers
+* `:create` - Creates the dmgr
+* `:start` - Starts the dmgr.
+* `:stop` - Stops the dmgr.
+* `:sync_all` - Syncs all federated nodes in the dmgr without restarting the appservers
 
 ### websphere_profiles
 
 This resource currently only allows for appserver or custom profiles. It's best to use custom resources everywhere, and add appservers to it later with the websphere_app_server or websphere_cluster_member resources.
 
+#### Example
 
-##### Example
 ```ruby
 websphere_profile 'AppProfile1' do
   admin_user 'admin'
@@ -120,39 +127,40 @@ websphere_profile 'AppProfile1' do
 end
 ```
 
-##### Parameters
+#### Parameters
 
-- `label`, String, name_property: true, just a label to make the execute resource name unique
-- `websphere_root`, String, default: '/opt/IBM/WebSphere/AppServer', The was install root
-- `bin_dir`, String, default: lazy { "#{websphere_root}/bin" } The path to the was root bin directory. No need to change this.
-- `admin_user`, [String, nil], default: nil, The dmgr user.  
-- `admin_password`, [String, nil], default: nil, The dmgr password.  This should only be known to people who know the server is managed with chef.
-- `dmgr_host`, String, default: 'localhost', The dmgr host to federate to.
-- `dmgr_port`, [String, nil], default: nil, The dmgr port to federate to.
-- `profile_name`, String
-- `node_name`, String, default: lazy { "#{profile_name}_node" }
-- `server_name`, String, default: lazy { "#{profile_name}_server" }
-- `cell_name`, [String, nil], default: nil
-- `java_sdk`, [String, nil], default: nil # The javasdk version must be already be installed using ibm-installmgr cookbook. If none is specified the embedded default is used. [See more](http://www.ibm.com/support/knowledgecenter/SS7JFU_8.5.5/com.ibm.websphere.express.doc/ae/rxml_managesdk.html)
-- `profile_type`, String, default: 'custom', Can be either appserver or custom, but easier to just use custom all the time and add jvms with websphere_app_server or websphere_cluster_member.
-- `attributes`, [Hash, nil], default: nil, These are custom attributes for the server when using the appserver type profile, such as monitoringPolicy. They are only set when the node is federated.
-- `manage_user`, [TrueClass, FalseClass], default: true. Should the resource create the user for you. Set to false if you have created the run_user previously in your recipe, outside of this resource.
-- `manage_service`, [TrueClass, FalseClass], default: true. Should the resource create the init service for you. Set to false if you have created the service previously in your recipe, outside of this resource.
-- `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
+* `label`, String, name_property: true, just a label to make the execute resource name unique
+* `websphere_root`, String, default: '/opt/IBM/WebSphere/AppServer', The WAS install root
+* `bin_dir`, String, default: lazy { "#{websphere_root}/bin" } The path to the was root bin directory. No need to change this.
+* `admin_user`, [String, nil], default: nil, The dmgr user.
+* `admin_password`, [String, nil], default: nil, The dmgr password.  This should only be known to people who know the server is managed with chef.
+* `dmgr_host`, String, default: 'localhost', The dmgr host to federate to.
+* `dmgr_port`, [String, nil], default: nil, The dmgr port to federate to.
+* `profile_name`, String, name_property: true
+* `node_name`, String, default: lazy { "#{profile_name}_node" }
+* `server_name`, String, default: lazy { "#{profile_name}_server" }
+* `cell_name`, [String, nil], default: nil
+* `java_sdk`, [String, nil], default: nil # The javasdk version must be already be installed using ibm-installmgr cookbook. If none is specified the embedded default is used. [See more](http://www.ibm.com/support/knowledgecenter/SS7JFU_8.5.5/com.ibm.websphere.express.doc/ae/rxml_managesdk.html)
+* `profile_type`, String, default: 'custom', Can be either appserver or custom, but easier to just use custom all the time and add jvms with websphere_app_server or websphere_cluster_member.
+* `attributes`, [Hash, nil], default: nil, These are custom attributes for the server when using the appserver type profile, such as monitoringPolicy. They are only set when the node is federated.
+* `manage_user`, [TrueClass, FalseClass], default: true. Should the resource create the user for you. Set to false if you have created the run_user previously in your recipe, outside of this resource.
+* `manage_service`, [TrueClass, FalseClass], default: true. Should the resource create the init service for you. Set to false if you have created the service previously in your recipe, outside of this resource.
+* `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
 
-##### Actions
+#### Actions
 
-- `:create` - Creates the profile
-- `:federate` - Adds the node to a deployment manager for federation/management.
-- `:start` - Starts the node.
-- `:stop` - Stops the node.
-- `:delete` - deletes node and profile and any servers on it. You need to delete any clusters before you can delete the node.
+* `:create` - Creates the profile
+* `:federate` - Adds the node to a deployment manager for federation/management.
+* `:start` - Starts the node.
+* `:stop` - Stops the node.
+* `:delete` - deletes node and profile and any servers on it. You need to delete any clusters before you can delete the node.
 
 ### websphere_app_server
 
 Adds a new jvm to an existing custom profile
 
-##### Example
+#### Example
+
 ```ruby
 websphere_app_server 'app_server1' do
   node_name 'Custom_node'
@@ -172,30 +180,31 @@ websphere_app_server 'app_server1' do
 end
 ```
 
-##### Parameters
+#### Parameters
 
-- `websphere_root`, String, default: '/opt/IBM/WebSphere/AppServer', The was install root.
-- `bin_dir`, String, default: lazy { "#{websphere_root}/bin" } The path to the was root bin directory. No need to change this.
-- `admin_user`, [String, nil], default: nil, The dmgr user.  
-- `admin_password`, [String, nil], default: nil, The dmgr password.  This should only be known to people who know the server is managed with chef.
-- `dmgr_host`, String, default: 'localhost', The dmgr host.
-- `dmgr_port`, [String, nil], default: nil, The dmgr port leave as nil for default 8879.
-- `server_name`, String, name_property: true, The new clustered server name
-- `server_node`, [String, nil], default: nil, required: true, The node to create the server on.
-- `attributes`, [Hash, nil], default: nil, A hash of attributes to apply to the server, eg. monitoringPolicy.
-- `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
+* `websphere_root`, String, default: '/opt/IBM/WebSphere/AppServer', The was install root.
+* `bin_dir`, String, default: lazy { "#{websphere_root}/bin" } The path to the was root bin directory. No need to change this.
+* `admin_user`, [String, nil], default: nil, The dmgr user.
+* `admin_password`, [String, nil], default: nil, The dmgr password.  This should only be known to people who know the server is managed with chef.
+* `dmgr_host`, String, default: 'localhost', The dmgr host.
+* `dmgr_port`, [String, nil], default: nil, The dmgr port leave as nil for default 8879.
+* `server_name`, String, name_property: true, The new clustered server name
+* `server_node`, [String, nil], default: nil, required: true, The node to create the server on.
+* `attributes`, [Hash, nil], default: nil, A hash of attributes to apply to the server, eg. monitoringPolicy.
+* `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
 
-##### Actions
+#### Actions
 
-- `:create` - Creates the server on node
-- `:delete` - Deletes the server
-- `:start` - Starts the server
+* `:create` - Creates the server on node
+* `:delete` - Deletes the server
+* `:start` - Starts the server
 
 ### websphere_cluster
 
 Creates an empty cluster to add app servers to.
 
-##### Example
+#### Example
+
 ```ruby
 websphere_cluster 'MyCluster' do
   admin_user 'admin'
@@ -205,31 +214,31 @@ websphere_cluster 'MyCluster' do
 end
 ```
 
-##### Parameters
+#### Parameters
 
-- `websphere_root`, String, default: '/opt/IBM/WebSphere/AppServer', The was install root
-- `bin_dir`, String, default: lazy { "#{websphere_root}/bin" } The path to the was root bin directory. No need to change this.
-- `admin_user`, [String, nil], default: nil, The dmgr user.  
-- `admin_password`, [String, nil], default: nil, The dmgr password.  This should only be known to people who know the server is managed with chef.
-- `dmgr_host`, String, default: 'localhost', The dmgr host to federate to.
-- `dmgr_port`, [String, nil], default: nil, The dmgr port to federate to.
-- `cluster_name`, String, name_property: true
-- `prefer_local`, [TrueClass, FalseClass], default: true
-- `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
+* `websphere_root`, String, default: '/opt/IBM/WebSphere/AppServer', The was install root
+* `bin_dir`, String, default: lazy { "#{websphere_root}/bin" } The path to the was root bin directory. No need to change this.
+* `admin_user`, [String, nil], default: nil, The dmgr user.
+* `admin_password`, [String, nil], default: nil, The dmgr password.  This should only be known to people who know the server is managed with chef.
+* `dmgr_host`, String, default: 'localhost', The dmgr host to federate to.
+* `dmgr_port`, [String, nil], default: nil, The dmgr port to federate to.
+* `cluster_name`, String, name_property: true
+* `prefer_local`, [TrueClass, FalseClass], default: true
+* `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
 
-##### Actions
+#### Actions
 
-- `:create` - Creates the cluster
-- `:delete` - Deletes the cluster
-- `:start` - Starts the servers on the cluster.
-- `:ripple_start` - Ripple starts servers on the cluster.
-
+* `:create` - Creates the cluster
+* `:delete` - Deletes the cluster
+* `:start` - Starts the servers on the cluster.
+* `:ripple_start` - Ripple starts servers on the cluster.
 
 ### websphere_cluster_member
 
 Creates and adds an application server to a cluster
 
-##### Example
+#### Example
+
 ```ruby
 websphere_cluster_member 'ClusterServer1' do
   cluster_name 'MyCluster'
@@ -251,36 +260,36 @@ websphere_cluster_member 'ClusterServer1' do
 end
 ```
 
-##### Parameters
+#### Parameters
 
-- `websphere_root`, String, default: '/opt/IBM/WebSphere/AppServer', The was install root.
-- `bin_dir`, String, default: lazy { "#{websphere_root}/bin" } The path to the was root bin directory. No need to change this.
-- `admin_user`, [String, nil], default: nil, The dmgr user.  
-- `admin_password`, [String, nil], default: nil, The dmgr password.  This should only be known to people who know the server is managed with chef.
-- `dmgr_host`, String, default: 'localhost', The dmgr host.
-- `dmgr_port`, [String, nil], default: nil, The dmgr port leave as nil for default 8879.
-- `cluster_name`, String
-- `prefer_local`, [TrueClass, FalseClass], default: true
-- `server_name`, String, name_property: true, The new clustered server name
-- `server_node`, [String, nil], default: nil, required: true, The node to create the server on.
-- `member_weight`, Fixnum, default: 2 # number from 0-100. Higher weight gets more traffic
-- `session_replication`, [TrueClass, FalseClass], default: false
-- `resources_scope`, String, default: 'both', regex: /^(both|server|cluster)$/
-- `attributes`, [Hash, nil], default: nil, A hash of attributes to apply to the server, eg. monitoringPolicy.
-- `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
+* `websphere_root`, String, default: '/opt/IBM/WebSphere/AppServer', The was install root.
+* `bin_dir`, String, default: lazy { "#{websphere_root}/bin" } The path to the was root bin directory. No need to change this.
+* `admin_user`, [String, nil], default: nil, The dmgr user.
+* `admin_password`, [String, nil], default: nil, The dmgr password.  This should only be known to people who know the server is managed with chef.
+* `dmgr_host`, String, default: 'localhost', The dmgr host.
+* `dmgr_port`, [String, nil], default: nil, The dmgr port leave as nil for default 8879.
+* `cluster_name`, String
+* `prefer_local`, [TrueClass, FalseClass], default: true
+* `server_name`, String, name_property: true, The new clustered server name
+* `server_node`, [String, nil], default: nil, required: true, The node to create the server on.
+* `member_weight`, Fixnum, default: 2 # number from 0-100. Higher weight gets more traffic
+* `session_replication`, [TrueClass, FalseClass], default: false
+* `resources_scope`, String, default: 'both', regex: /^(both|server|cluster)$/
+* `attributes`, [Hash, nil], default: nil, A hash of attributes to apply to the server, eg. monitoringPolicy.
+* `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
 
-##### Actions
+#### Actions
 
-- `:create` - Creates the server and adds to cluster
-- `:delete` - Deletes the server
-- `:start` - Starts the server
-
+* `:create` - Creates the server and adds to cluster
+* `:delete` - Deletes the server
+* `:start` - Starts the server
 
 ### websphere_app
 
 Deploys an application to a server or cluster
 
-##### Example
+#### Example
+
 ```ruby
 websphere_app 'sample_app_cluster' do
   app_file '/tmp/sample.war'
@@ -291,35 +300,35 @@ websphere_app 'sample_app_cluster' do
 end
 ```
 
-##### Parameters
+#### Parameters
 
-- `websphere_root`, String, default: '/opt/IBM/WebSphere/AppServer', The was install root
-- `bin_dir`, String, default: lazy { "#{websphere_root}/bin" } The path to the was root bin directory. No need to change this.
-- `admin_user`, [String, nil], default: nil, The dmgr user.  
-- `admin_password`, [String, nil], default: nil, The dmgr password.
-- `dmgr_host`, String, default: 'localhost', The dmgr host to federate to.
-- `dmgr_port`, [String, nil], default: nil, The dmgr port to federate to.
-- `app_name`, String, name_property: true
-- `app_file`, [String, nil], default: nil, required: true
-- `server_name`, [String, nil], default: nil
-- `node_name`, [String, nil], default: nil
-- `cluster_name`, [String, nil], default: nil
-- `context_root`, [String, nil], default: nil
-- `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
+* `websphere_root`, String, default: '/opt/IBM/WebSphere/AppServer', The was install root
+* `bin_dir`, String, default: lazy { "#{websphere_root}/bin" } The path to the was root bin directory. No need to change this.
+* `admin_user`, [String, nil], default: nil, The dmgr user.
+* `admin_password`, [String, nil], default: nil, The dmgr password.
+* `dmgr_host`, String, default: 'localhost', The dmgr host to federate to.
+* `dmgr_port`, [String, nil], default: nil, The dmgr port to federate to.
+* `app_name`, String, name_property: true
+* `app_file`, [String, nil], default: nil, required: true
+* `server_name`, [String, nil], default: nil
+* `node_name`, [String, nil], default: nil
+* `cluster_name`, [String, nil], default: nil
+* `context_root`, [String, nil], default: nil
+* `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
 
-##### Actions
+#### Actions
 
-- `:deploy_to_cluster` - Deploys app to a cluster
-- `:deploy_to_server` - Deploys app to a server
-- `:start` - Starts the app
-- `:stop` - Stops the app
-
+* `:deploy_to_cluster` - Deploys app to a cluster
+* `:deploy_to_server` - Deploys app to a server
+* `:start` - Starts the app
+* `:stop` - Stops the app
 
 ### websphere_ihs
 
 Deploys an ihs webserver to an existing profile/node.  It currently only supports `managed` ihs webservers.
 
-##### Example
+#### Example
+
 ```ruby
 websphere_ihs 'MyWebserver1' do
   config_type 'local_distributed'
@@ -333,41 +342,40 @@ websphere_ihs 'MyWebserver1' do
 end
 ```
 
-##### Parameters
+#### Parameters
 
-- `websphere_root`, String, default: '/opt/IBM/WebSphere/AppServer', The was install root
-- `bin_dir`, String, default: lazy { "#{websphere_root}/bin" } The path to the was root bin directory. No need to change this.
-- `admin_user`, [String, nil], default: nil, The dmgr user.  
-- `admin_password`, [String, nil], default: nil, The dmgr password.
-- `dmgr_host`, String, default: 'localhost', The dmgr host to federate to.
-- `dmgr_port`, [String, nil], default: nil, The dmgr port to federate to.
-- `webserver_name`, String, name_property: true
-- `plg_root`, String, default: '/opt/IBM/WebSphere/Plugins'
-- `wct_root`, String, default: '/opt/IBM/WebSphere/Toolbox'
-- `wct_tool_root`, String, default: lazy { "#{wct_root}/WCT" }
-- `config_type`, String, default: 'local_distributed', Can only be local_distributed or remote.
-- `profile_name`, String, required: true
-- `node_name`, String, required: true
-- `map_to_apps`, [TrueClass, FalseClass], default: false
-- `ihs_hostname`, [String],  default: lazy { node.name }
-- `ihs_port`, String, default: '80'
-- `ihs_install_root`, default: '/opt/IBM/HTTPServer'
-- `ihs_config_file`, String, default: lazy { "#{ihs_install_root}/conf/httpd.conf" }
-- `runas_user`, String, default: 'root'
-- `runas_group`, String, default: 'root'
-- `enable_ihs_admin_server`, [TrueClass, FalseClass], default: false
-- `ihs_admin_user`, [String, nil], default: nil
-- `ihs_admin_password`, [String, nil], default: nil
-- `ihs_admin_port`, String, default: '8008'
-- `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
+* `websphere_root`, String, default: '/opt/IBM/WebSphere/AppServer', The was install root
+* `bin_dir`, String, default: lazy { "#{websphere_root}/bin" } The path to the was root bin directory. No need to change this.
+* `admin_user`, [String, nil], default: nil, The dmgr user.
+* `admin_password`, [String, nil], default: nil, The dmgr password.
+* `dmgr_host`, String, default: 'localhost', The dmgr host to federate to.
+* `dmgr_port`, [String, nil], default: nil, The dmgr port to federate to.
+* `webserver_name`, String, name_property: true
+* `plg_root`, String, default: '/opt/IBM/WebSphere/Plugins'
+* `wct_root`, String, default: '/opt/IBM/WebSphere/Toolbox'
+* `wct_tool_root`, String, default: lazy { "#{wct_root}/WCT" }
+* `config_type`, String, default: 'local_distributed', Can only be local_distributed or remote.
+* `profile_name`, String, required: true
+* `node_name`, String, required: true
+* `map_to_apps`, [TrueClass, FalseClass], default: false
+* `ihs_hostname`, [String],  default: lazy { node.name }
+* `ihs_port`, String, default: '80'
+* `ihs_install_root`, default: '/opt/IBM/HTTPServer'
+* `ihs_config_file`, String, default: lazy { "#{ihs_install_root}/conf/httpd.conf" }
+* `runas_user`, String, default: 'root'
+* `runas_group`, String, default: 'root'
+* `enable_ihs_admin_server`, [TrueClass, FalseClass], default: false
+* `ihs_admin_user`, [String, nil], default: nil
+* `ihs_admin_password`, [String, nil], default: nil
+* `ihs_admin_port`, String, default: '8008'
+* `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
 
-##### Actions
+#### Actions
 
-- `:create` - Creates a web definition and deploys a webserver
-- `:delete` - deletes the web definition
-- `:start` - starts the webserver
-- `:stop` - stops the webserver
-
+* `:create` - Creates a web definition and deploys a webserver
+* `:delete` - deletes the web definition
+* `:start` - starts the webserver
+* `:stop` - stops the webserver
 
 ### ibm_cert
 
@@ -375,7 +383,8 @@ Used to manage ibm java certificates.  Create keystore, create certificates and 
 
 This can be used on any server with ikeycmd tool.
 
-##### Example
+#### Example
+
 ```ruby
 ibm_cert 'mydomain.com' do
   dn 'CN=mydomain.com,O=MyOrg,C=UK'
@@ -396,36 +405,35 @@ ibm_cert 'myotherdomain.com' do
 end
 ```
 
-##### Parameters
+#### Parameters
 
-- `label`, String, name_property: true
-- `dn`, String, required: true eg "CN=mydomain.com,O=MyOrg,C=UK"
-- `kdb`, String, required: true, regex: Path to keystore file. Will create if it doesn't exist. File must end in .kdb or .p12
-- `kdb_password`, String, required: true
-- `algorithm`, String, default: 'SHA256WithRSA'
-- `size`, String, default: '2048', Can be 2048, 1024 or 512
-- `expire`, String, default: '3600', required: true
-- `extract_to`, String, Used by the extract action only. Extracts in ASCII to a file <label>.cer next to the keystore file location by default. #{label}.cer" } .
-- `add_cert`, [String, nil], default: nil  path to certificate to add to keystore, only used in add.
-- `default_cert`, String, default: 'no'. Can be yes or no
-- `ikeycmd`, String, default: /opt/IBM/WebSphere/AppServer/java/jre/bin/ikeycmd path to ikeycmd tool.
-- `owned_by`, String, default: 'root'
-- `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
+* `label`, String, name_property: true
+* `dn`, String, required: true eg "CN=mydomain.com,O=MyOrg,C=UK"
+* `kdb`, String, required: true, regex: Path to keystore file. Will create if it doesn't exist. File must end in .kdb or .p12
+* `kdb_password`, String, required: true
+* `algorithm`, String, default: 'SHA256WithRSA'
+* `size`, String, default: '2048', Can be 2048, 1024 or 512
+* `expire`, String, default: '3600', required: true
+* `extract_to`, String, Used by the extract action only. Extracts in ASCII to a file <label>.cer next to the keystore file location by default. #{label}.cer" } .
+* `add_cert`, [String, nil], default: nil  path to certificate to add to keystore, only used in add.
+* `default_cert`, String, default: 'no'. Can be yes or no
+* `ikeycmd`, String, default: /opt/IBM/WebSphere/AppServer/java/jre/bin/ikeycmd path to ikeycmd tool.
+* `owned_by`, String, default: 'root'
+* `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
 
-##### Actions
+#### Actions
 
-- `:create` - Creates a keystore with a default certificate
-- `:extract` - extracts a certificate from a keystore
-- `:add` - adds an existing certificate to an existing keystore.
-- `:import` - import a new certificate to an existing keystore.
-- `:update` - update a certificate in an existing keystore with the same label.
-
+* `:create` - Creates a keystore with a default certificate
+* `:extract` - extracts a certificate from a keystore
+* `:add` - adds an existing certificate to an existing keystore.
+* `:import` - import a new certificate to an existing keystore.
+* `:update` - update a certificate in an existing keystore with the same label.
 
 ### websphere_env
 
 Creates a websphere environment variable
 
-##### Example
+#### Example
 
 ```ruby
 websphere_env 'TESTING_1234' do
@@ -436,23 +444,23 @@ websphere_env 'TESTING_1234' do
   action :set
 end
 ```
-##### Parameters
 
-- `variable_name`, [String, nil], name_property.
-- `scope`, String, required: true. eg Cell=Cell1
-- `value`, [String, nil], default: nil
+#### Parameters
 
-##### Actions
+* `variable_name`, [String, nil], name_property.
+* `scope`, String, required: true. eg Cell=Cell1
+* `value`, [String, nil], default: nil
 
-- `:set` - creates the variable and sets the value.
-- `:remove` - removes the variable.
+#### Actions
 
+* `:set` - creates the variable and sets the value.
+* `:remove` - removes the variable.
 
 ### websphere_jms_provider
 
 Creates a custom jms provder in websphere
 
-##### Example
+#### Example
 
 ```ruby
 websphere_jms_provider 'ActiveMQ' do
@@ -468,26 +476,25 @@ websphere_jms_provider 'ActiveMQ' do
 end
 ```
 
-##### Parameters
+#### Parameters
 
-- `provider_name`, String, name_property: true. Unique name for the custom provider.
-- `scope`, String, required: true. eg Cell=Cell1
-- `context_factory`, [String, nil], default: nil
-- `url`, [String, nil], default: nil
-- `classpath_jars`, [Array, nil], default: nil Full path to each jar driver
-- `description`, [String, nil], default: nil
-- `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
+* `provider_name`, String, name_property: true. Unique name for the custom provider.
+* `scope`, String, required: true. eg Cell=Cell1
+* `context_factory`, [String, nil], default: nil
+* `url`, [String, nil], default: nil
+* `classpath_jars`, [Array, nil], default: nil Full path to each jar driver
+* `description`, [String, nil], default: nil
+* `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
 
-##### Actions
+#### Actions
 
-- `:create` - Creates a jms provider
-
+* `:create` - Creates a jms provider
 
 ### websphere_jms_conn_factory
 
 Creates a jms connection factory
 
-##### Example
+#### Example
 
 ```ruby
 websphere_jms_conn_factory 'My Queue Conection Factory' do
@@ -504,35 +511,34 @@ websphere_jms_conn_factory 'My Queue Conection Factory' do
 end
 ```
 
-##### Parameters
+#### Parameters
 
-- `conn_factory_name`, String, name_property: true
-- `scope`, String, required: true eg 'Cell=MyCell,Cluster=MyCluster'
-- `jndi_name`, String, required: true
-- `ext_jndi_name`, String, required: true
-- `jms_provider`, String, required: true
-- `type`, String, required: true, Can be only QUEUE, TOPIC or UNIFIED
-- `description`, [String, nil], default: nil
-- `category`, [String, nil], default: nil
-- `conn_pool_timeout`, String, default: '180'
-- `conn_pool_min`, String, default: '1'
-- `conn_pool_max`, String, default: '10'
-- `conn_pool_reap_time`, String, default: '180'
-- `conn_pool_unused_timeout`, String, default: '1800'
-- `conn_aged_timeout`, String, default: '0'
-- `conn_purge_policy`, String, default: 'FailingConnectionOnly' can be only FailingConnectionOnly or EntirePool
-- `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
+* `conn_factory_name`, String, name_property: true
+* `scope`, String, required: true eg 'Cell=MyCell,Cluster=MyCluster'
+* `jndi_name`, String, required: true
+* `ext_jndi_name`, String, required: true
+* `jms_provider`, String, required: true
+* `type`, String, required: true, Can be only QUEUE, TOPIC or UNIFIED
+* `description`, [String, nil], default: nil
+* `category`, [String, nil], default: nil
+* `conn_pool_timeout`, String, default: '180'
+* `conn_pool_min`, String, default: '1'
+* `conn_pool_max`, String, default: '10'
+* `conn_pool_reap_time`, String, default: '180'
+* `conn_pool_unused_timeout`, String, default: '1800'
+* `conn_aged_timeout`, String, default: '0'
+* `conn_purge_policy`, String, default: 'FailingConnectionOnly' can be only FailingConnectionOnly or EntirePool
+* `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
 
-##### Actions
+#### Actions
 
-- `:create` - Creates a jms conection factory
-
+* `:create` - Creates a jms conection factory
 
 ### websphere_jms_destination
 
 Creates a jms queue or topic
 
-##### Example
+#### Example
 
 ```ruby
 websphere_jms_destination 'My Queue' do
@@ -548,22 +554,21 @@ websphere_jms_destination 'My Queue' do
 end
 ```
 
-##### Parameters
+#### Parameters
 
-- `jms_dest_name`, String, name_property: true
-- `jndi_name`, String, required: true
-- `ext_jndi_name`, String, required: true
-- `scope`, String, required: true eg 'Cell=MyCell,Cluster=MyCluster'
-- `jms_provider`, String, required: true
-- `type`, String, required: true, Can be QUEUE, TOPIC or UNIFIED
-- `description`, [String, nil], default: nil
-- `category`, [String, nil], default: nil
-- `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
+* `jms_dest_name`, String, name_property: true
+* `jndi_name`, String, required: true
+* `ext_jndi_name`, String, required: true
+* `scope`, String, required: true eg 'Cell=MyCell,Cluster=MyCluster'
+* `jms_provider`, String, required: true
+* `type`, String, required: true, Can be QUEUE, TOPIC or UNIFIED
+* `description`, [String, nil], default: nil
+* `category`, [String, nil], default: nil
+* `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
 
-##### Actions
+#### Actions
 
-- `:create` - Creates a jms queue or topic
-
+* `:create` - Creates a jms queue or topic
 
 ### websphere_wsadmin
 
@@ -587,19 +592,17 @@ websphere_wsadmin 'do some more wsadmin' do
 end
 ```
 
-##### Parameters
+#### Parameters
 
-- `label`, String, name_property: true, just a label to make the execute resource name unique
-- `script`, [String, nil], default: nil. The command for wsadmin to run.  If a file is given this will be ignored, and only the file will be executed.
-- `file`, [String, nil], default: nil The script file for wsadmin to run.
-- `return_codes`, Array, default: [0]. Return codes to allow.
-- `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
-
+* `label`, String, name_property: true just a label to make the execute resource name unique
+* `script`, [String, nil], default: nil. The command for wsadmin to run.  If a file is given this will be ignored, and only the file will be executed.
+* `file`, [String, nil], default: nil The script file for wsadmin to run.
+* `return_codes`, Array, default: [0]. Return codes to allow.
+* `sensitive_exec`, [TrueClass, FalseClass], default: true # set to false for debug purposes to show stdout in chef logs.
 
 ## License and Author
 
 * Authors: Lachlan Munro (<lachlan.munro@sainsburys.co.uk>), Chris Bell (<chris.bell@sainsburys.co.uk>)
-
 
 Copyright: 2016, J Sainsburys
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -33,9 +33,9 @@ module WebsphereCookbook
     # returns cell name for a profile path
     # assumes only one cell folder can exist in a profile config path
     def profile_cell(p_path)
-      ::Dir.chdir("#{p_path}/config/cells")
-      cell = ::Dir.glob('*').select { |f| ::File.directory? f }
-      cell.first
+      return unless ::File.exist?("#{p_path}/bin/setupCmdLine.sh")
+      cell = ::File.open("#{p_path}/bin/setupCmdLine.sh").grep(/^WAS_CELL=/).first.split('=')
+      cell.last.chomp
     end
 
     def template_lookup(profle_type, profile_templates_dir)

--- a/libraries/websphere_cluster_member.rb
+++ b/libraries/websphere_cluster_member.rb
@@ -62,7 +62,7 @@ module WebsphereCookbook
       # it can take a minute to create the clustered server, so we need to add a delay in if it cannot find it.
       sleep(30) if !server_exists?(server_node, server_name) || !member?(cluster_name, server_name)
       sleep(30) if !server_exists?(server_node, server_name) || !member?(cluster_name, server_name)
-      start_server(server_node, server_name) if server_exists?(server_node, server_name) || member?(cluster_name, server_name)
+      start_server(cluster_name, server_name, server_node) if server_exists?(server_node, server_name) || member?(cluster_name, server_name, server_node)
       # node.normal['websphere']['endpoints'][server_name] = get_ports(server_node,server_name)
       node.default['websphere']['endpoints'] = get_ports
       # Chef::Log.debug("endpoints set #{node['websphere']['endpoints'][server_node][server_name]}")
@@ -70,7 +70,7 @@ module WebsphereCookbook
 
     action :delete do
       # TODO: delete server using the object id so you don't need as many inputs to delete it.
-      delete_cluster_member(cluster_name, server_name, server_node, session_replication) if server_exists?(server_node, server_name) && member?(cluster_name, server_name)
+      delete_cluster_member(cluster_name, server_name, server_node, session_replication) if server_exists?(server_node, server_name) && member?(cluster_name, server_name, server_node)
       save_config
       # if no more cluster members, delete cluster so it can be recreated with new template
       # delete_cluster(cluster_name) unless get_cluster_members(cluster_name).count > 0

--- a/libraries/websphere_dmgr.rb
+++ b/libraries/websphere_dmgr.rb
@@ -31,6 +31,7 @@ module WebsphereCookbook
     property :java_sdk, [String, nil], default: nil # javasdk version must be already be installed using ibm-installmgr cookbook. If none is specified the embedded default is used
     property :security_attributes, [Hash, nil], default: nil # these are set when the Dmgr is started
     property :manage_user, [TrueClass, FalseClass], default: true
+    property :profile_env, [Hash, nil], default: nil # start/stop environment parameters
 
     # creates a new profile or augments/updates if profile exists.
     action :create do
@@ -63,11 +64,7 @@ module WebsphereCookbook
     end
 
     action :start do
-      # service node_name do
-      #   action :start
-      # end
-      # start_profile(profile_name, bin_dir, "./startManager.sh -profileName #{profile_name}", [0, 255])
-      start_manager(profile_name)
+      start_manager(profile_name, profile_env, "#{profile_path}/bin")
 
       # set attributes on dmgr
       ruby_block 'set security attributes' do

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'lachlan.munro@sainsburys.co.uk'
 license 'Apache-2.0'
 description 'Installs/Configures IBM Websphere'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.11'
+version '1.0.12'
 supports 'redhat'
 supports 'centos'
 

--- a/spec/unit/recipes/spec_helper.rb
+++ b/spec/unit/recipes/spec_helper.rb
@@ -3,7 +3,7 @@ require 'chefspec/berkshelf'
 
 RSpec.configure do |config|
   config.platform = 'centos'
-  config.version = '6.6'
+  config.version = '6.8'
   config.log_level = :error
   # Prohibit using the should syntax
   config.expect_with :rspec do |spec|
@@ -19,7 +19,7 @@ end
 def stub_commands
   stub_command('which sudo').and_return('/usr/bin/sudo')
   # allow(File).to receive(:exist?).and_call_original
-  # allow(File).to receive(:exist?).with('/opt/IBM/WebSphere/AppServer/profiles/AppProfile1/config/cells').and_return(true)
+  # allow(File).to receive(:exist?).with('/opt/IBM/WebSphere/AppServer/profiles/AppProfile1/bin/setupCmdLine.sh').and_return(true)
 end
 
 at_exit { ChefSpec::Coverage.report! }

--- a/spec/unit/recipes/was_cluster_spec.rb
+++ b/spec/unit/recipes/was_cluster_spec.rb
@@ -7,20 +7,26 @@ describe 'websphere-test::was_cluster' do
     stub_commands
     ChefSpec::ServerRunner.new(
       step_into: %w(websphere_dmgr websphere_profile websphere_cluster websphere_cluster_member websphere_ihs websphere_app),
-      platform: 'centos',
-      version: '6.6'
+      platform: 'centos'
     ) do |node|
-      node.set['websphere-test']['passport_advantage']['user'] = 'dummyuser'
-      node.set['websphere-test']['passport_advantage']['password'] = 'dummypw'
+      node.automatic['websphere-test']['passport_advantage']['user'] = 'dummyuser'
+      node.automatic['websphere-test']['passport_advantage']['password'] = 'dummypw'
     end.converge('websphere-test::was_cluster')
   end
 
-  it 'includes recipe websphere-test::was_install' do
-    expect(chef_run).to include_recipe('websphere-test::was_install')
+  %w(
+    websphere-test::was_install_basic
+    websphere-test::was_fixpack_java7
+  ).each do |recipe|
+    it "includes recipe #{recipe}" do
+      expect(chef_run).to include_recipe(recipe)
+    end
   end
 
   it 'creates Dmgr01 profile with manageprofiles.sh' do
-    expect(chef_run).to run_execute('manage_profiles ./manageprofiles.sh -create Dmgr01').with(sensitive: true)
+    expect(chef_run).to run_execute('manage_profiles ./manageprofiles.sh -create Dmgr01').with(
+      sensitive: true
+    )
   end
 
   it 'creates an init script with attributes' do
@@ -36,6 +42,9 @@ describe 'websphere-test::was_cluster' do
   end
 
   it 'starts dmgr' do
-    expect(chef_run).to run_execute('start dmgr profile: Dmgr01').with(command: './startManager.sh -profileName Dmgr01')
+    expect(chef_run).to run_execute('start dmgr profile: Dmgr01').with(
+      command: './startManager.sh -profileName Dmgr01',
+      cwd: '/opt/IBM/WebSphere/AppServer/profiles/Dmgr01/bin'
+    )
   end
 end

--- a/templates/default/dmgr_init.d.erb
+++ b/templates/default/dmgr_init.d.erb
@@ -1,5 +1,4 @@
 #!/bin/sh
-#
 
 # IBM Confidential OCO Source Material
 # 5724-I63, 5724-H88, 5655-N02, 5733-W70 (C) COPYRIGHT International Business Machines Corp. 2005, 2006
@@ -9,19 +8,19 @@
 
 # The next lines are for chkconfig on RedHat systems.
 # chkconfig: 2345 98 02
-# description: Starts and stops WebSphere Application Server \
+# description: Starts and stops WebSphere Deployment Manager \
 #              instances. This service was created via the \
 #              wasservice command.
 
 # The next lines are for chkconfig on SuSE systems.
 ### BEGIN INIT INFO
-# Provides: WebSphere_init_AppServer12_node
+# Provides: WebSphere_init_Deployment_Manager
 # Required-Start: $network $syslog
 # Required-Stop:
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 6
-# Short-Description: Starts and stops WebSphere Application Server instances
-# Description: Starts and stops WebSphere Application Server instances
+# Short-Description: Starts and stops WebSphere Deployment Manager instances
+# Description: Starts and stops WebSphere Deployment Manager instances
 ### END INIT INFO
 
 
@@ -37,8 +36,8 @@ SERVICENAME="<%= @service_name %>"
 RUNASUSER="<%= @runas_user %>"
 # END BLOCK
 
-startScript=startServer.sh
-stopScript=stopServer.sh
+startScript=startManager.sh
+stopScript=stopManager.sh
 
 binDir="${PROFILEPATH}/bin"
 LOCKFILE="/var/lock/subsys/${SERVICENAME}"
@@ -51,16 +50,16 @@ start_was()
 {
     startCmd="${binDir}/${startScript}"
     if [ -f "${startCmd}" -a -x "${startCmd}" ] ; then
-        echo "Starting WebSphere Application Server - ${SERVERNAME} ..."
+        echo "Starting WebSphere Deployment Manager - ${SERVERNAME} ..."
         if [ -z "${RUNASUSER}" ]; then
-          "${startCmd}" "${SERVERNAME}" ${STARTARGS} $@
+          "${startCmd}" ${STARTARGS} $@
         else
-          su -c "\"${startCmd}\" \"${SERVERNAME}\" ${STARTARGS} $@" ${RUNASUSER}
+          su -c "\"${startCmd}\" ${STARTARGS} $@" ${RUNASUSER}
         fi
         RETVAL=$?
         [ $RETVAL -eq 0 ] && touch "${LOCKFILE}"
     else
-        echo "Failure starting WebSphere Application Server - ${SERVERNAME}"
+        echo "Failure starting WebSphere Deployment Manager - ${SERVERNAME}"
         echo "The service definition may be invalid - script ${startCmd}"
         echo "could not be found or was not executable."
     fi
@@ -70,16 +69,16 @@ stop_was()
 {
     stopCmd="${binDir}/${stopScript}"
     if [ -f "${stopCmd}" -a -x "${stopCmd}" ] ; then
-        echo "Stopping WebSphere Application Server - $SERVERNAME ..."
+        echo "Stopping WebSphere Deployment Manager - $SERVERNAME ..."
         if [ -z "${RUNASUSER}" ]; then
-          "${stopCmd}" "${SERVERNAME}" ${STOPARGS} $@
+          "${stopCmd}" ${STOPARGS} $@
         else
-          su -c "\"${stopCmd}\" \"${SERVERNAME}\" ${STOPARGS} $@" ${RUNASUSER}
+          su -c "\"${stopCmd}\" ${STOPARGS} $@" ${RUNASUSER}
         fi
         RETVAL=$?
         [ $RETVAL -eq 0 ] && rm -f "${LOCKFILE}"
     else
-        echo "Failure stopping WebSphere Application Server - ${SERVERNAME}"
+        echo "Failure stopping WebSphere Deployment Manager - ${SERVERNAME}"
         echo "The service definition may be invalid - script ${stopCmd}"
         echo "could not be found or was not executable."
     fi
@@ -88,9 +87,9 @@ stop_was()
 stat_was()
 {
     if ps ax | grep -v grep | grep "${PROFILEPATH}" | grep "${SERVERNAME}" > /dev/null ; then
-        echo "WebSphere Application Server - $SERVERNAME is running."
+        echo "WebSphere Deployment Manager - $SERVERNAME is running."
     else
-        echo "WebSphere Application Server - $SERVERNAME is not running."
+        echo "WebSphere Deployment Manager - $SERVERNAME is not running."
     fi
 }
 

--- a/test/fixtures/cookbooks/websphere-test/recipes/was_cluster.rb
+++ b/test/fixtures/cookbooks/websphere-test/recipes/was_cluster.rb
@@ -4,6 +4,7 @@ include_recipe 'websphere-test::was_fixpack_java7'
 websphere_dmgr 'Dmgr01 create' do
   profile_name 'Dmgr01'
   cell_name 'MyNewCell'
+  node_name 'MyNewNode'
   admin_user 'admin'
   admin_password 'admin'
   security_attributes ({
@@ -56,6 +57,7 @@ end
 
 websphere_cluster_member 'ClusterServer1' do
   cluster_name 'MyCluster'
+  server_name 'ClusterServer1-node'
   server_node 'CustomProfile1_node'
   admin_user 'admin'
   admin_password 'admin'

--- a/test/integration/was-cluster/serverspec/default_spec.rb
+++ b/test/integration/was-cluster/serverspec/default_spec.rb
@@ -40,6 +40,13 @@ services.each do |service|
   end
 end
 
+describe file('/etc/init.d/Dmgr01') do
+  its(:content) { should match(/startScript=startManager.sh/) }
+end
+describe file('/etc/init.d/AppProfile1_node') do
+  its(:content) { should match(/startScript=startServer.sh/) }
+end
+
 describe file('/opt/IBM/WebSphere/AppServer/profiles/Dmgr01/config/cells/MyNewCell/nodes/CustomProfile1_node/servers/ClusterServer1/server.xml') do
   it { should be_owned_by 'was' }
   it { should be_grouped_into 'was' }


### PR DESCRIPTION
- Deployment Manager should be controlled with startManager and stopManager. Create a separate script for this
- add init.d/functions call
- allow environment variables to be passed to the startManager call
- README updates