### PR TITLE
Allow the key database expiry time to be set via parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,8 @@ end
 * `kdb_password`, String, required: true
 * `algorithm`, String, default: 'SHA256WithRSA'
 * `size`, String, default: '2048', Can be 2048, 1024 or 512
-* `expire`, String, default: '3600', required: true
+* `expire`, String, default: '3600', required: true. The expiry for the certificate being created
+* `expire_kdb`, String, default: '7300', required: false. The expiry time (in days) for the key database
 * `extract_to`, String, Used by the extract action only. Extracts in ASCII to a file <label>.cer next to the keystore file location by default. #{label}.cer" } .
 * `add_cert`, [String, nil], default: nil  path to certificate to add to keystore, only used in add.
 * `default_cert`, String, default: 'no'. Can be yes or no

--- a/libraries/ibm_cert.rb
+++ b/libraries/ibm_cert.rb
@@ -25,6 +25,7 @@ module WebsphereCookbook
     property :algorithm, String, default: 'SHA256WithRSA'
     property :size, String, default: '2048', regex: /^(2048|1024|512)$/
     property :expire, String, default: '3600', required: true
+    property :expire_kdb, String, default: '7300', required: false
     property :extract_to, String, default: lazy { "#{::File.dirname(kdb)}/#{label}.cer" } # used by the extract action only. extracts to given file in ascii format
     property :add_cert, [String, nil], default: nil # path to certificate to add/import to kdb, only used in add/import.
     property :kdb_type, String, default: 'pkcs12' # type of key database
@@ -127,7 +128,7 @@ module WebsphereCookbook
         end
 
         execute "create kdb #{kdb}" do
-          command "#{ikeycmd} -keydb -create -db #{kdb} -pw #{kdb_password} -type cms -expire 7300 -stash"
+          command "#{ikeycmd} -keydb -create -db #{kdb} -pw #{kdb_password} -type cms -expire #{expire_kdb} -stash"
           sensitive sensitive_exec
           action :run
           creates kdb


### PR DESCRIPTION
- The keystore default of 20 years can break on older Java & OS due to the year 2038 problem. Allow it to be set as the user wishes