### PR TITLE
fix a bug with get_cluster_members function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 IBM Websphere Cookbook CHANGELOG
 ========================
 
+v1.1.4
+--------------------
+- Bug fix for `websphere_base`:`get_cluster_members` function, did not return successful output previously
+
 v1.1.3
 --------------------
 - Bug fix for `websphere_base`:`enable_as_service` function

--- a/libraries/websphere_base.rb
+++ b/libraries/websphere_base.rb
@@ -479,6 +479,7 @@ module WebsphereCookbook
           members << server
         end
         Chef::Log.debug("get_cluster_members() result #{members}")
+        members
       end
 
       # returns true if server exists on node.

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'GOL.CloudEngineering@sainsburys.co.uk'
 license 'Apache-2.0'
 description 'Installs/Configures IBM Websphere'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.3'
+version '1.1.4'
 supports 'redhat'
 supports 'centos'
 


### PR DESCRIPTION
- the get_cluster_members function did not return the successful output of members which can fail in interesting ways with adding members to a cluster