### PR TITLE
Add multiple cluster members in a single wsadmin update

### DIFF
--- a/libraries/websphere_base.rb
+++ b/libraries/websphere_base.rb
@@ -544,6 +544,24 @@ module WebsphereCookbook
         end
       end
 
+      def wsadmin_multi_command_exec(label, cmd, return_codes = [0], bin_directory = new_resource.bin_dir)
+        wsadmin_cmd = './wsadmin.sh -lang jython -conntype SOAP '
+        wsadmin_cmd << "-host #{new_resource.dmgr_host} " if new_resource.dmgr_host
+        wsadmin_cmd << "-port #{new_resource.dmgr_port} " if new_resource.dmgr_port
+        wsadmin_cmd << "-user #{new_resource.admin_user} -password #{new_resource.admin_password} " if new_resource.admin_user && new_resource.admin_password
+        wsadmin_cmd << "#{cmd}"
+        Chef::Log.debug("wsadmin_exec running cmd: #{wsadmin_cmd} return_codes #{return_codes}")
+
+        execute "wsadmin #{label}" do
+          cwd bin_directory
+          user new_resource.run_user
+          command wsadmin_cmd
+          returns return_codes
+          sensitive new_resource.sensitive_exec
+          action :run
+        end
+      end
+
       def wsadmin_exec_file(label, cmd, return_codes = [0], bin_directory = new_resource.bin_dir)
         wsadmin_cmd = './wsadmin.sh -lang jython -conntype SOAP '
         wsadmin_cmd << "-host #{new_resource.dmgr_host} " if new_resource.dmgr_host


### PR DESCRIPTION
During a recent converge of a scheduler node in production we saw multiple periods of increased response time on the customer web site. These corresponded to the addition of each jvm on the new node.

To reduce the impact of the addition of JVMs; add all of them in one wsadmin call rather than one at a time.

This has the benefit of significantly reduce initial converge time as well. Testing on an instance with 4 jvm's we took about 5 mins off of the converge; one assumes this will double with our 8 jvm instances. Additionally; it should also reduce the amount of blocking we get when multiple nodes are trying to converge at once during environment create.

This change is backwards compatible with the old syntax for adding cluster members. A PR for the chef repo is coming as well