### PR TITLE
DCE-2038: Create a dependency between node agent and jvm start up on systemd boxes

### DIFF
--- a/libraries/websphere_base.rb
+++ b/libraries/websphere_base.rb
@@ -159,7 +159,7 @@ module WebsphereCookbook
 
       # use to setup a nodeagent or dmgr as a service
       # server_name should be 'dmgr' or 'nodeagent'
-      def enable_as_service(service_name, srvr_name, prof_path, runas = 'root')
+      def enable_as_service(service_name, srvr_name, prof_path, runas = 'root', dependent_service = nil)
         # if dplymgr user and password set, then add as additional args for stop.
         stop_args = new_resource.admin_user && new_resource.admin_password ? "-username #{new_resource.admin_user} -password #{new_resource.admin_password}" : ''
         # admin_user && admin_password ? start_args = "-username #{admin_user} -password #{admin_password}" : start_args = ''
@@ -212,7 +212,8 @@ module WebsphereCookbook
               stop_args: stop_args,
               start_args: '',
               svc_timeout: srvr_name == 'dmgr' ? new_resource.dmgr_svc_timeout : new_resource.node_svc_timeout,
-              runas_user: runas
+              runas_user: runas,
+              dependent_service: dependent_service
             )
           end
         else

--- a/libraries/websphere_profile.rb
+++ b/libraries/websphere_profile.rb
@@ -65,7 +65,7 @@ module WebsphereCookbook
           create_service_account(new_resource.run_user, new_resource.run_group)
         end
         if new_resource.manage_service == true
-          enable_as_service(new_resource.profile_name + '_node', 'nodeagent', new_resource.profile_path, new_resource.run_user)
+          enable_as_service(new_resource.profile_name + '_node', 'nodeagent', new_resource.profile_path, new_resource.run_user, new_resource.profile_name, new_resource.profile_name + '.service')
           # the addNode command will start a node agent process which upsets systemd
           if node['init_package'] == 'systemd'
             stop_args = new_resource.admin_user && new_resource.admin_password ? "-username #{new_resource.admin_user} -password #{new_resource.admin_password}" : ''
@@ -139,7 +139,7 @@ module WebsphereCookbook
           create_service_account(new_resource.run_user, new_resource.run_group)
         end
         if new_resource.manage_service == true
-          enable_as_service(new_resource.profile_name + '_node', 'nodeagent', new_resource.profile_path, new_resource.run_user)
+          enable_as_service(new_resource.profile_name + '_node', 'nodeagent', new_resource.profile_path, new_resource.run_user, new_resource.profile_name + '.service')
           # the addNode command will start a node agent process which upsets systemd
           if node['init_package'] == 'systemd'
             stop_args = new_resource.admin_user && new_resource.admin_password ? "-username #{new_resource.admin_user} -password #{new_resource.admin_password}" : ''

--- a/templates/default/node_service_systemd.erb
+++ b/templates/default/node_service_systemd.erb
@@ -1,5 +1,8 @@
 [Unit]
 Description=IBM WebSphere Application Server Node Service
+<% unless @dependent_service.nil? -%>
+Before=<%= @dependent_service %>
+<% end -%>
 
 [Service]
 ExecStart=<%= @profile_path %>/bin/startNodeSystemd.sh <%= @start_args %>
@@ -11,3 +14,6 @@ SuccessExitStatus=143
 
 [Install]
 WantedBy=multi-user.target
+<% unless @dependent_service.nil? -%>
+WantedBy=<%= @dependent_service %>
+<% end -%>


### PR DESCRIPTION
Ensure that the node agent is started prior to the application jvm's trying to come up. This prevents errors during start up when the system is under load