### PR TITLE
fix(was): Correct parameters to federate call

### DIFF
--- a/libraries/websphere_profile.rb
+++ b/libraries/websphere_profile.rb
@@ -65,7 +65,7 @@ module WebsphereCookbook
           create_service_account(new_resource.run_user, new_resource.run_group)
         end
         if new_resource.manage_service == true
-          enable_as_service(new_resource.profile_name + '_node', 'nodeagent', new_resource.profile_path, new_resource.run_user, new_resource.profile_name, new_resource.profile_name + '.service')
+          enable_as_service(new_resource.profile_name + '_node', 'nodeagent', new_resource.profile_path, new_resource.run_user, new_resource.profile_name + '.service')
           # the addNode command will start a node agent process which upsets systemd
           if node['init_package'] == 'systemd'
             stop_args = new_resource.admin_user && new_resource.admin_password ? "-username #{new_resource.admin_user} -password #{new_resource.admin_password}" : ''


### PR DESCRIPTION
Correct the copy paste error which was blocking additional nodes from federating

Kitchen output of a web node converging

```
       Chef Infra Client finished, 658/2323 resources updated in 18 minutes 39 seconds
       Downloading files from <wcs-node-web-wasv8-redhat-7-chef>
       Finished converging <wcs-node-web-wasv8-redhat-7-chef> (19m14.98s).
-----> Test Kitchen is finished. (20m44.22s)


Test Summary: 145 successful, 0 failures, 0 skipped
       Finished verifying <wcs-node-web-wasv8-redhat-7-chef> (1m35.33s).
-----> Test Kitchen is finished. (1m42.57s)

```